### PR TITLE
Add github actions for linux

### DIFF
--- a/.github/ci/configure_github_actions.cmake
+++ b/.github/ci/configure_github_actions.cmake
@@ -1,0 +1,29 @@
+if (DEFINED "ENV{GITHUB_ACTIONS}")
+  set(CTEST_SITE "github-actions")
+else ()
+  message(WARNING "This script is being run outside of a GitHub Actions environment")
+
+  get_filename_component(project_root_dir "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)
+  set(ENV{GITHUB_WORKSPACE} ${project_root_dir})
+endif ()
+
+set(CTEST_SOURCE_DIRECTORY "$ENV{GITHUB_WORKSPACE}")
+set(CTEST_BINARY_DIRECTORY "${CTEST_SOURCE_DIRECTORY}/build")
+
+set(CTEST_BUILD_NAME "lwlog-ci")
+
+if (ENV{CMAKE_BUILD_TYPE})
+  set(CTEST_BUILD_CONFIGURATION "$ENV{CMAKE_BUILD_TYPE}")
+endif ()
+
+if (ENV{CMAKE_GENERATOR})
+  set(CTEST_CMAKE_GENERATOR "$ENV{CMAKE_GENERATOR}")
+else ()
+  set(CTEST_CMAKE_GENERATOR "Ninja")
+endif ()
+
+if (NOT DEFINED ENV{CTEST_MAX_PARALLELISM})
+  set(ENV{CTEST_MAX_PARALLELISM} 2)
+endif ()
+
+set(CTEST_TEST_TIMEOUT 50)

--- a/.github/ci/ctest_build.cmake
+++ b/.github/ci/ctest_build.cmake
@@ -1,0 +1,15 @@
+include(${CMAKE_CURRENT_LIST_DIR}/configure_github_actions.cmake)
+
+ctest_read_custom_files("${CTEST_BINARY_DIRECTORY}")
+
+# Pick up from where configure left off
+ctest_start(APPEND)
+
+# Run build
+ctest_build(
+  NUMBER_WARNINGS num_warning 
+  RETURN_VALUE build_result)
+
+if (ENV{CTEST_NO_WARNINGS_ALLOWED} AND num_warning GREATER 0)
+  message(FATAL_ERROR "Encountered unallowed warnings during build")
+endif ()

--- a/.github/ci/ctest_configure.cmake
+++ b/.github/ci/ctest_configure.cmake
@@ -1,0 +1,23 @@
+include(${CMAKE_CURRENT_LIST_DIR}/configure_github_actions.cmake)
+
+set(cmake_args -DLWLOG_BUILD_EXAMPLES:BOOL=ON -DENABLE_TESTING:BOOL=ON)
+
+ctest_start("Continuous" TRACK "Experimental")
+
+# Update the branch to the latest
+find_package(Git)
+set(CTEST_UPDATE_VERSION_ONLY ON)
+set(CTEST_UPDATE_COMMAND "${GIT_EXECUTABLE}")
+ctest_update()
+
+# Run configuration
+ctest_configure(
+  OPTIONS "${cmake_args}"
+  RETURN_VALUE configure_result)
+
+ctest_read_custom_files("${CTEST_BINARY_DIRECTORY}")
+
+if (configure_result)
+  message(FATAL_ERROR
+    "Failed to configure")
+endif ()

--- a/.github/ci/ctest_test.cmake
+++ b/.github/ci/ctest_test.cmake
@@ -1,0 +1,13 @@
+include(${CMAKE_CURRENT_LIST_DIR}/configure_github_actions.cmake)
+
+ctest_read_custom_files("${CTEST_BINARY_DIRECTORY}")
+
+# Pick up from where build left off
+ctest_start(APPEND)
+
+ctest_test(APPEND
+  RETURN_VALUE test_result)
+
+if (test_result)
+  message(FATAL_ERROR "Failed to test")
+endif ()

--- a/.github/ci/linux/install_deps.sh
+++ b/.github/ci/linux/install_deps.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Install build tools
+sudo apt install \
+  binutils clang cmake ninja-build

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,0 +1,35 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - dev
+      - master
+      - github_actions_linux 
+  pull_request:
+    branches:
+      - dev
+      - master 
+
+jobs:
+  linux-build-and-test:
+    runs-on: ubuntu-latest
+    env:
+      CMAKE_GENERATOR: Ninja
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Deps
+        run: .github/ci/linux/install_deps.sh
+      - name: Configure
+        run: ctest -S .github/ci/ctest_configure.cmake
+      - name: Build
+        run: ctest -S .github/ci/ctest_build.cmake
+      - name: Test
+        run: ctest -S .github/ci/ctest_test.cmake
+      - name: Save Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-artifact
+          path: build
+          retention-days: 1


### PR DESCRIPTION
I thought you might like this as well, some CI for making sure everything still works using `ctest`. Since the project is converted to be a CMake project it is pretty trivial and the cmake scripts in `.github/ci` are cross platform so adding CI for other platforms should be trivial to do.