### PR TITLE
don't hardcode flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ find_package(Threads REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "-O3")
 message("Compiler Version: ${CMAKE_CXX_COMPILER_VERSION}")
 
 set(version 1.2.0)


### PR DESCRIPTION
If this should be published on vcpkg, you should not hardcode flags. The end user should be in control of how to compile the project. If you need special presets of flags, I suggest using cmake presets for that :) 