### PR TITLE
fixed error "multiple definition of `lwlog::details::alignment_info::…

### DIFF
--- a/lwlog/include/details/pattern/alignment_formatter_impl.h
+++ b/lwlog/include/details/pattern/alignment_formatter_impl.h
@@ -2,7 +2,7 @@
 
 namespace lwlog::details
 {
-	alignment_info::alignment_info(char fill_char, align_side side, std::uint8_t width, std::string_view flag)
+	inline alignment_info::alignment_info(char fill_char, align_side side, std::uint8_t width, std::string_view flag)
 		: fill_char{ fill_char }
 		, side{ side }
 		, width{ width }


### PR DESCRIPTION
fixed error described in [https://github.com/ChristianPanov/lwlog/issues/73](https://github.com/ChristianPanov/lwlog/issues/73)